### PR TITLE
Fixed iframe from pushing sidebar

### DIFF
--- a/dist/styles/bellows.css
+++ b/dist/styles/bellows.css
@@ -34,6 +34,10 @@
 }
 
 /* hide youtube player */
-div.yt-player {
+.yt-player {
+	position: absolute; 
+	width:0; 
+	height:0; 
+	border:0;
 	display: none;
 }

--- a/static/styles/bellows.css
+++ b/static/styles/bellows.css
@@ -34,6 +34,10 @@
 }
 
 /* hide youtube player */
-div.yt-player {
+.yt-player {
+	position: absolute; 
+	width:0; 
+	height:0; 
+	border:0;
 	display: none;
 }


### PR DESCRIPTION
## Context
This pull request is a bandaid fix for Foundry version 0.9.283. It aims to fix the Foundry sidebar from moving to the side when playing music through Bellows as described in issue #53. This problem results from the Youtube iframe player moving the Foundry Sidebar to the middle. 

## My Changes
**Changes**:
- Replaced `div.yt-player` to just `.yt-player` since the player is an iframe
- In addition to not showing a display, the `yt-player` iframe is now shrunk to 0 pixels and uses absolute positioning to ensure that it cannot interfere with the Foundry UI. 

## Testing
These changes were tested by interacting with the Foundry UI on a D&D5e world. Whilst logged in as both a Gamemaster and as a player I have checked to make sure that the youtube player still runs without moving the sidebar for both ambient and playlist sounds. 